### PR TITLE
Allow assembler to accept custom filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,31 @@ Este projeto contém um montador simples escrito em Python para a CPU descrita n
 ![image](https://github.com/user-attachments/assets/2525d152-0dbe-43c1-af7a-a94bce82ac07)
 
 
-O script `montador.py` converte um arquivo `program.asm`, escrito em assembly compatível com o computador do livro, em um arquivo `program.txt` no formato `v3.0 hex words plain` (usado em ferramentas como o Logisim para inicializar memória).
+O script `montador.py` converte um arquivo assembly em um arquivo `program.txt` no formato `v3.0 hex words plain` (usado em ferramentas como o Logisim para inicializar memória). Por padrão ele procura `program.asm`, mas é possível indicar qualquer arquivo de entrada pela linha de comando.
 
 ## Como usar
 
-1. Crie um arquivo chamado `program.asm` no mesmo diretório contendo o programa em assembly. Cada instrução pode ser separada por espaços ou vírgulas e os comentários começam com `;`.
-2. Execute o montador:
+1. Crie um arquivo `program.asm` (ou outro nome de sua escolha) contendo o programa em assembly. Cada instrução pode ser separada por espaços ou vírgulas e os comentários começam com `;`.
+2. Execute o montador indicando o arquivo de entrada e opcionalmente o de saída:
 
 ```bash
-python3 montador.py
+python3 montador.py seu_programa.asm -o resultado.txt
 ```
 
-3. O arquivo `program.txt` será gerado com os códigos de máquina em hexadecimal, prontos para serem carregados na memória do simulador.
+Se nenhum arquivo for informado, o montador usa `program.asm` e gera `program.txt`.
+
+Antes de executar, é possível compilar os arquivos Python para verificar
+erros de sintaxe utilizando `py_compile`:
+
+```bash
+python3 -m py_compile arquivo1.py montador.py
+```
+
+Em seguida rode o montador normalmente:
+
+```bash
+python3 montador.py seu_programa.asm -o resultado.txt
+```
 
 ## Conjunto de Instruções
 

--- a/montador.py
+++ b/montador.py
@@ -1,3 +1,5 @@
+import argparse
+
 memory = 256*["00"]
 
 intruções = {"R0" : "00",
@@ -75,7 +77,6 @@ def ler_arquivo_asm(arquivo):
         programa_asm[i] = programa_asm[i].replace(","," ")
         programa_asm[i] = programa_asm[i].split()
     programa_asm = list(filter(bool, programa_asm))
-    print(programa_asm)
     return programa_asm
 
 def conversao(programa_asm):
@@ -223,11 +224,26 @@ def escrever_saida(arquivo):
             f.write(codigo)
             f.write("\n")
 
-def montador():
-    print("executando como script principal.")
-    programa_asm = ler_arquivo_asm("program.asm")
+def montador(argv=None):
+    """Executa o montador utilizando argumentos de linha de comando."""
+    parser = argparse.ArgumentParser(description="Montador OC")
+    parser.add_argument(
+        "source",
+        nargs="?",
+        default="program.asm",
+        help="Arquivo de entrada em assembly",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="program.txt",
+        help="Arquivo de saída gerado",
+    )
+    args = parser.parse_args(argv)
+
+    programa_asm = ler_arquivo_asm(args.source)
     conversao(programa_asm)
-    escrever_saida("program.txt")
+    escrever_saida(args.output)
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `argparse` CLI to specify input and output files
- remove debug print from parser
- update README with optional `py_compile` step

## Testing
- `python3 -m py_compile montador.py`


------
https://chatgpt.com/codex/tasks/task_e_684ca996e8188323b63e077708018889