### PR TITLE
Implementa validação de overflow para endereços decimais

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ python3 montador.py seu_programa.asm -o resultado.txt
 
 Se nenhum arquivo for informado, o montador usa `program.asm` e gera `program.txt`.
 
+Endereços informados em decimal devem estar no intervalo de -128 a 255. Valores fora desse
+intervalo resultarão em erro de conversão.
+
 Antes de executar, é possível compilar os arquivos Python para verificar
 erros de sintaxe utilizando `py_compile`:
 

--- a/montador.py
+++ b/montador.py
@@ -47,6 +47,8 @@ def bin(n, width: int = 4, twos_complement: bool = False):
 
 def decBin(n):
     n = int(n)
+    if n < -128 or n > 255:
+        raise ValueError("Valor decimal fora do intervalo permitido [-128, 255]")
     return "0b" + format(n & 0xFF, "08b")
 
 def normalizaNumero (s):
@@ -242,7 +244,11 @@ def montador(argv=None):
     args = parser.parse_args(argv)
 
     programa_asm = ler_arquivo_asm(args.source)
-    conversao(programa_asm)
+    try:
+        conversao(programa_asm)
+    except ValueError as e:
+        print(f"Erro: {e}")
+        return
     escrever_saida(args.output)
     
 


### PR DESCRIPTION
## Summary
- valida intervalo ao converter decimal para binário
- captura o erro na função `montador`
- documenta a nova regra no README

## Testing
- `python3 -m py_compile montador.py`
- `python3 montador.py test.asm -o output.txt` *(gera erro ao usar valor fora do intervalo)*

------
https://chatgpt.com/codex/tasks/task_e_684de053455c832393dfb7855f4d1a3a