### PR TITLE
Handle HALT without operand

### DIFF
--- a/montador.py
+++ b/montador.py
@@ -262,11 +262,14 @@ def conversao(programa_asm, labels: dict[str, int]):
             inst = normalizaNumero(inst)
             memory[mem] = inst
             mem += 1
-            inst = tokens[1]
-            if not is_numero(inst):
-                if inst not in labels:
-                    raise ValueError("label indefinida")
-                inst = str(labels[inst])
+            if len(tokens) > 1:
+                inst = tokens[1]
+                if not is_numero(inst):
+                    if inst not in labels:
+                        raise ValueError("label indefinida")
+                    inst = str(labels[inst])
+            else:
+                inst = str(mem - 1)
             inst = normalizaNumero(inst)
             memory[mem] = inst
             mem += 1


### PR DESCRIPTION
## Summary
- allow the `HALT` pseudo-instruction to omit the operand

## Testing
- `python3 montador.py vector_swap.asm -o vector_swap.txt`

------
https://chatgpt.com/codex/tasks/task_e_686206c4b5588323b43317c03b87b0f5