### PR TITLE
Fix SHOW_RESULT formatting in assembly

### DIFF
--- a/program.asm
+++ b/program.asm
@@ -60,7 +60,8 @@ READ_INPUT: IN      DATA R0         ; ‘D’ (dezena)
             ADD     R0 R2           ; dezena*10
             ADD     R0 R1           ; + unidade  → dividendo pronto
             JMP     AFTER_READ
-SHOW_RESULT:DATA    R3 QUOT
+SHOW_RESULT:
+DATA    R3 QUOT
             LD      R1 R3           ; R1 = quociente
             DATA    R2 0x30
             ADD     R1 R2           ; para ASCII


### PR DESCRIPTION
## Summary
- split the `SHOW_RESULT:` label and its data instruction onto separate lines for clarity
- verify assembly generates output without errors

## Testing
- `python3 montador.py program.asm -o program.txt`

------
https://chatgpt.com/codex/tasks/task_e_686c0d13e0e48323a410b8a6be2b4e4c