### PR TITLE
Fix pseudo-instruction sizes in assembler

### DIFF
--- a/montador.py
+++ b/montador.py
@@ -100,11 +100,14 @@ def tamanho_instrucao(tokens: list[str]) -> int:
     if op == "HALT":
         return 2
     if op == "MOVE":
-        # MOVE é considerado uma instrução única
-        return 1
+        # MOVE é expandido em duas instruções (XOR + OR)
+        return 2
     if op == "CLR":
         # CLR gera apenas um XOR registrador consigo mesmo
         return 1
+    # Saltos condicionais formados por combinações de C, A, E e Z
+    if set(op).issubset(set(jcaez)):
+        return 2
     return 1
 
 
@@ -375,10 +378,6 @@ def montador(argv=None):
         return
     escrever_saida(args.output)
     
-
-# Execucao direta
-if __name__ == "__main__":
-    montador()    
 
 # Execucao direta
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- correct size accounting for MOVE and conditional jumps
- remove duplicated `__main__` section

## Testing
- `python3 -m py_compile montador.py && python3 montador.py program.asm -o program_output.txt && wc -l program_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_686c0e71aa8483238afda17c4aab1848